### PR TITLE
Enable testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: python
+
 python:
   - 2.7
   - 3.3
   - 3.4
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - gfortran
+
 install:
-  - sudo apt-get update
-  - sudo apt-get install -qq gfortran
   - pip install --no-deps .
+
 script:
   - cd test
   - python test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - 2.7
+  - 3.3
+  - 3.4
+install:
+  - sudo apt-get update
+  - sudo apt-get install -qq gfortran
+  - pip install --no-deps .
+script:
+  - cd test
+  - python test.py

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ FRUITPy is a module for building and running Fortran unit tests using a Python i
 
 Enjoy a slice of FRUITPy while maintaining Fortran!
 
+[![Build Status](https://travis-ci.org/acroucher/FRUITPy.svg)](https://travis-ci.org/acroucher/FRUITPy)
+
 # Installing FRUITPy:
 
 First, you need to have FRUIT itself installed on your machine. If you want to use FRUITPy for parallel unit testing using MPI, you will need FRUIT version 3.3.0 or later.


### PR DESCRIPTION
It seems a bit odd that a library for testing does not itself get tested, no? You will need to enable Travis on your repo to get it working first.

It doesn't look like FRUIT itself is actually used in the tests, though?

~~Note: this is based on #3.~~
