### PR TITLE
Minor fixes and setuptools

### DIFF
--- a/FRUIT.py
+++ b/FRUIT.py
@@ -285,7 +285,7 @@ class test_suite(object):
         Setting the update parameter to True forces the executable to
         be rebuilt."""
         from subprocess import call
-        from os.path import isfile, splitext, split
+        from os.path import isfile, splitext, split, join
         from os import remove
         import shlex
         from sys import platform
@@ -293,7 +293,7 @@ class test_suite(object):
         source_path, self.exe = split(self.exe)
         if platform == 'win32':
             self.exe += ".exe"
-        pathexe = output_dir + self.exe
+        pathexe = join(output_dir, self.exe)
         if isfile(pathexe) and update:
             remove(pathexe)
         if not isinstance(build_command, list):

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Enjoy a slice of FRUITPy while maintaining Fortran!
 
 First, you need to have FRUIT itself installed on your machine. If you want to use FRUITPy for parallel unit testing using MPI, you will need FRUIT version 3.3.0 or later.
 
-All you really need are the two main FRUIT source files, fruit.f90 and fruit_util.f90 (and fruit_mpi.f90 for parallel unit testing). You need to be able to link your Fortran unit test code to these files. You can either compile them in directly (as suggested by the FRUIT developers) or you may prefer to compile these two files into a library that you can link to. A makefile for doing that is included with FRUITPy (fruit_makefile)- just copy this to the FRUIT base directory, rename it as 'makefile' and type `make` and then `make install`. (You can edit the INSTALL_DIR and INCL_DIR in the makefile if you want the library and Fortran module files installed somewhere different from the defaults.)
+All you really need are the main FRUIT source files, fruit.f90 and fruit_util.f90 (for newer versions of FRUIT, the util module was integrated into fruit.f90 so there is no fruit_util.f90) and fruit_mpi.f90 for parallel unit testing. You need to be able to link your Fortran unit test code to these files. You can either compile them in directly (as suggested by the FRUIT developers) or you may prefer to compile these two files into a library that you can link to. A makefile for doing that is included with FRUITPy (fruit_makefile)- just copy this to the FRUIT base directory, rename it as 'makefile' and type `make` and then `make install`. (You can edit the INSTALL_DIR and INCL_DIR in the makefile if you want the library and Fortran module files installed somewhere different from the defaults.)
 
-To install FRUITPy, either download the zip file and unzip it, or clone the FRUITPy Git repository, as you prefer.
+To install FRUITPy, first you need [`setuptools`](https://github.com/pypa/setuptools) (e.g. from `pip`: `pip install setuptools`). Then either download the zip file and unzip it, or clone the FRUITPy Git repository, as you prefer.
 
-Then you may install it by running `python setup.py install`, in the FRUITPy directory.
+Now you may install it by running `python setup.py install`, in the FRUITPy directory. If you plan to do development work, you can alternatively run `python setup.py develop`. This ensures that changes in your copy of the FRUITpy source are directly reflected in the installation.
 
 # Running Fortran unit tests using FRUITPy:
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# PyTOUGH setup script
+# FRUITpy setup script
 
 from __future__ import (absolute_import, division, print_function)
 

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-from distutils.core import setup
-
+from setuptools import setup
 
 setup(name='FRUITPy',
       version='0.1.0',


### PR DESCRIPTION
Some very minor fixes and switch from `distutils` to `setuptools`.

The latter might be controversial since it introduces a dependency so I understand if you don't want to merge that in. However, IMHO, it is always worth it to use `setuptools`. Being able to do `python setup.py develop` alone justifies having to do `pip install setuptools`, I think. Happy to discuss that, though :-).