### PR TITLE
Fix compilation errors of fortran files under test directory

### DIFF
--- a/test/adder.F90
+++ b/test/adder.F90
@@ -40,7 +40,7 @@ contains
 
     self%result = self%a + self%b
 
-  end subroutine adder_init
+  end subroutine adder_add
 
 !------------------------------------------------------------------------
 

--- a/test/adder_test.F90
+++ b/test/adder_test.F90
@@ -1,6 +1,8 @@
-module adder_test
+module adder_test_module
 
   use adder_module
+  use fruit
+  
   implicit none
 
   real :: tol = 1.e-6
@@ -9,7 +11,7 @@ module adder_test
 
 !------------------------------------------------------------------------
 
-    subroutine adder_test(adder, a, b, c)
+    subroutine adder_test(a, b, c)
 
       type(adder_type) :: adder
       real, intent(in) :: a, b, c
@@ -69,4 +71,4 @@ module adder_test
 
 !------------------------------------------------------------------------
 
-end module adder_test
+end module adder_test_module

--- a/test/setup.F90
+++ b/test/setup.F90
@@ -1,7 +1,6 @@
 module setup_module
 
   implicit none
-  private
 
   real, public :: x = 0.0
 


### PR DESCRIPTION
adder.F90: incorrect name in end subroutine

adder_test.F90: rename module to avoid conflict with subroutine name, use fruit module to get assert_equals, adder in adder_test routine needs to be local

setup.F90: routines must be public in order to call them from generated driver program