### PR TITLE
Fix exception in Python 3

### DIFF
--- a/FRUIT.py
+++ b/FRUIT.py
@@ -334,7 +334,10 @@ class test_suite(object):
 
     def parse_output(self, output):
         """Parses output."""
-        self.output_lines = output.decode().splitlines()
+        try:
+            self.output_lines = output.decode().splitlines()
+        except AttributeError:
+            self.output_lines = output.splitlines()
         self.get_success()
         self.get_messages()
         self.get_statistics()

--- a/test/test.py
+++ b/test/test.py
@@ -103,6 +103,35 @@ class FRUITPyTestCase(unittest.TestCase):
         self.subroutine_test(mod.subroutines[1],
                              "test_2", "Test 2 with setup")
 
+    def test_parse_output(self):
+        """Tests parsing of FRUIT output."""
+
+        suite = FRUIT.test_suite([])
+        output  = " Test module initialized\n\n"
+        output += "    . : successful assert,   F : failed assert\n\n"
+        output += ".......F.......F\n\n"
+        output += "     Start of FRUIT summary:\n\n"
+        output += " Some tests failed!\n\n"
+        output += "   -- Failed assertion messages:\n"
+        output += "   [TEST_ABC]:Expected [4], Got [3]\n"
+        output += "   [TEST_DEF]:Expected [3], Got [4]\n"
+        output += "   -- end of failed assertion messages.\n\n"
+        output += " Total asserts :             16\n"
+        output += " Successful    :             14\n"
+        output += " Failed        :              2\n"
+        output += "Successful rate:    87.50%\n\n"
+        output += " Successful asserts / total asserts : [           14 /          16  ]\n"
+        output += " Successful cases   / total cases   : [            2 /           4  ]\n"
+        output += "   -- end of FRUIT summary"
+        suite.parse_output(output)
+        self.assertEqual(False, suite.success)
+        self.assertEqual(14, suite.asserts.success)
+        self.assertEqual(16, suite.asserts.total)
+        self.assertEqual(2, suite.cases.success)
+        self.assertEqual(4, suite.cases.total)
+        self.assertEqual(2, len(suite.messages))
+        self.assertEqual("[TEST_ABC]:Expected [4], Got [3]", suite.messages[0])
+        self.assertEqual("[TEST_DEF]:Expected [3], Got [4]", suite.messages[1])
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(FRUITPyTestCase)


### PR DESCRIPTION
Fix exception in Python 3 caused by str not having decode method. Add unit test covering test_suite.parse_output in which the exception occurred.