### PR TITLE
Fix fruit_makefile

### DIFF
--- a/fruit_makefile
+++ b/fruit_makefile
@@ -25,5 +25,5 @@ $(BUILD)/%$(OBJ): $(SRC)/%$(F90)
 	$(FC) $(FLAGS) -c $< -o $@
 
 install :
-	cp $(LIB) $(INSTALL_DIR)
+	cp $(LIB) $(INSTALL_DIR)/$(LIB)
 	cp *.mod $(INCL_DIR)


### PR DESCRIPTION
Previous functionality would simply create a file in the home directory called `lib`.

Instead, the desired functionality is to place `libfruit.so` into the *directory* called `lib`.